### PR TITLE
Use promises and fetch instead of eventemitter and xhr

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,22 +58,26 @@ A simple example for Chrome/FF, which does not attempt to solve some of the mobi
 ```js
 var createPlayer = require('web-audio-player')
 
-var audio = createPlayer('assets/audio.mp3')
+createPlayer('assets/audio.mp3')
+  .then(function(player) {
+    // start playing audio file
+    player.play()
 
-audio.on('load', () => {
-  console.log('Audio loaded...')
-  
-  // start playing audio file
-  audio.play()
-  
-  // and connect your node somewhere, such as
-  // the AudioContext output so the user can hear it!
-  audio.node.connect(audio.context.destination)
-})
+    // and connect your node somewhere, such as
+    // the AudioContext output so the user can hear it!
+    player.node.connect(player.context.destination)
 
-audio.on('ended', () => {
-  console.log('Audio ended...')
-})
+    // do something when the audio finished playing
+    function audioEnded () {
+      console.log('Audio ended...')
+    }
+    if (player.isBuffer) {
+      player.node.onended = audioEnded
+    } else {
+      player.source.addEventListener('ended', audioEnded)
+    }
+  })
+
 ```
 
 For a complete mobile/desktop demo, see [demo/index.js](demo/index.js). See [Gotchas](#webaudio-gotchas) for more details.
@@ -114,35 +118,17 @@ The `AudioContext` being used for this player. You should re-use audio contexts 
 
 The `AudioNode` for this WebAudio player.
 
-#### `player.element`
+#### `player.isBuffer`
 
-If `buffer` is false (the source is a media element), this will be the `HTMLAudioElement` or `Audio` object that is driving the audio. 
+`true` if the source is a buffer. `false` if it's a media element.
 
-If the source is a buffer, this will be undefined.
+#### `player.source`
+
+Either the media element or the buffer.
 
 #### `player.duration`
 
 The duration of the audio track in seconds. This will most likely only return a meaningful value after the `'load'` event.
-
-### events
-
-#### `player.on('load', fn)`
-
-Called when the player has loaded, and the audio can be played. With a media element, this is after `'canplay'`. With a buffer source, this is after the audio has been decoded.
-
-#### `player.on('end', fn)`
-
-If the audio is not looping, this is called when the audio playback ends.
-
-#### `player.on('error', fn)`
-
-Called with `(err)` parameters when there was an error loading, buffering or decoding the audio.
-
-#### `player.on('decoding', fn)`
-
-If `buffer: true`, this will be called after the XMLHttpRequest, and before `decodeAudioData` starts. This alows you to provide an update to your user as the audio loads.
-
-This is not called with a media element source.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -138,17 +138,29 @@ If the audio is not looping, this is called when the audio playback ends.
 
 Called with `(err)` parameters when there was an error loading, buffering or decoding the audio.
 
-#### `player.on('progress', fn)`
-
-If `buffer: true`, this will be called on the progress events of the XMLHttpRequest for the audio file (if the browser supports it). The parameters will be `(percentage, totalBytes)`.
-
-This is not called with a media element source.
-
 #### `player.on('decoding', fn)`
 
 If `buffer: true`, this will be called after the XMLHttpRequest, and before `decodeAudioData` starts. This alows you to provide an update to your user as the audio loads.
 
 This is not called with a media element source.
+
+## Dependencies
+
+If you're using buffer mode and a browser [that doesn't support fetch](http://caniuse.com/#search=fetch)
+you can polyfill it with [github/fetch](https://github.com/github/fetch).
+
+Install the module:
+
+```
+npm i --save whatwg-fetch
+```
+
+And use it before loading this library:
+
+```
+require('whatwg-fetch')
+require('web-audio-player')
+```
 
 ## Roadmap
 
@@ -158,7 +170,7 @@ Some new features may be added to this module, such as:
 - Adding a seek or `play(N)` feature
 - Adding a few more events
 - Supporting pause/play with buffered sources if possible
-- Supporting caching or re-using the XHR response
+- Supporting caching or re-using the fetch response
 - Supporting a list of formats like OGG, WAV, MP3
 
 Please open an issue or PR if you wish to discuss a new feature.

--- a/demo/index.js
+++ b/demo/index.js
@@ -62,13 +62,22 @@ function start (audioContext, shouldBuffer) {
   audioPlayer('demo/bluejean_short.mp3', {
     context: audioContext,
     buffer: shouldBuffer,
-    loop: true
+    loop: false
   }).then(function (player) {
     // Set up our AnalyserNode utility
     // Make sure to use the same AudioContext as our player!
     var audioUtil = createAnalyser(player.node, player.context, {
       stereo: false
     })
+
+    function audioEnded () {
+      console.log('Audio ended...')
+    }
+    if (player.isBuffer) {
+      player.node.onended = audioEnded
+    } else {
+      player.source.addEventListener('ended', audioEnded)
+    }
 
     // The actual AnalyserNode
     var analyser = audioUtil.analyser

--- a/lib/augment-player.js
+++ b/lib/augment-player.js
@@ -1,0 +1,24 @@
+module.exports = augmentPlayer
+function augmentPlayer(player) {
+  Object.defineProperties(player, {
+    currentTime: {
+      enumerable: true, configurable: true,
+      get: function () {
+        // TODO review for buffer
+        if (player.source) {
+          return player.source.currentTime
+        }
+      }
+    },
+    duration: {
+      enumerable: true, configurable: true,
+      get: function () {
+        if (player.source) {
+          return player.source.duration
+        }
+      }
+    }
+  })
+
+  return player
+}

--- a/lib/buffer-source.js
+++ b/lib/buffer-source.js
@@ -1,49 +1,29 @@
+var augmentPlayer = require('./augment-player')
 var createAudioContext = require('./audio-context')
-var EventEmitter = require('events').EventEmitter
 
 module.exports = createBufferSource
 function createBufferSource (src, opt) {
   if (typeof src !== 'string') {
-    throw new TypeError('Buffered source currently must be a single file')
+    reject(new TypeError('Buffered source currently must be a single file'))
   }
 
   opt = opt || {}
-  var emitter = new EventEmitter()
   var audioContext = opt.context || createAudioContext()
   var node = audioContext.createBufferSource()
-  node.onended = ended
 
   if (opt.loop) {
     node.loop = true
   }
 
-  fetch(src)
+  return fetch(src)
     .then(checkStatus)
     .then(parseArrayBuffer)
     .then(decode)
+    .then(getPlayer)
     .catch(catchError)
 
-  emitter.play = node.start.bind(node, 0)
-  emitter.pause = node.stop.bind(node, 0)
-  emitter.node = node
-  emitter.context = audioContext
-
-  Object.defineProperties(emitter, {
-    duration: {
-      enumerable: true, configurable: true,
-      get: function () {
-        if (node.buffer && typeof node.buffer.duration !== 'undefined') {
-          return node.buffer.duration
-        }
-        return undefined
-      }
-    }
-  })
-
-  return emitter
-
   function catchError (err) {
-    emitter.emit('error', err)
+    reject(err);
   }
 
   function checkStatus (response) {
@@ -57,19 +37,28 @@ function createBufferSource (src, opt) {
   }
 
   function decode (arrayBuf) {
-    emitter.emit('decoding')
-    audioContext.decodeAudioData(arrayBuf, function (buffer) {
-      node.buffer = buffer
-      emitter.emit('load')
-    }, function () {
-      var err = new Error('Error decoding audio data')
-      err.type = 'DECODE_AUDIO_DATA'
-      emitter.emit('error', err)
-    })
+    return new Promise(function(resolve, reject) {
+      audioContext.decodeAudioData(arrayBuf, function (buffer) {
+        resolve(buffer)
+      }, function decodeError () {
+        var err = new Error('Error decoding audio data')
+        err.type = 'DECODE_AUDIO_DATA'
+        reject(err)
+      })
+    });
   }
 
-  function ended () {
-    emitter.emit('end')
+  function getPlayer (buffer) {
+    node.buffer = buffer
+
+    return augmentPlayer({
+      context: audioContext,
+      isBuffer: true,
+      node: node,
+      source: buffer,
+      pause: node.stop.bind(node, 0),
+      play: node.start.bind(node, 0)
+    })
   }
 
   function parseArrayBuffer (response) {

--- a/lib/buffer-source.js
+++ b/lib/buffer-source.js
@@ -1,6 +1,4 @@
 var createAudioContext = require('./audio-context')
-var xhr = require('xhr')
-var xhrProgress = require('xhr-progress')
 var EventEmitter = require('events').EventEmitter
 
 module.exports = createBufferSource
@@ -19,23 +17,11 @@ function createBufferSource (src, opt) {
     node.loop = true
   }
 
-  var xhrObject = xhr({
-    uri: src,
-    responseType: 'arraybuffer'
-  }, function (err, resp, arrayBuf) {
-    if (!/^2/.test(resp.statusCode)) {
-      err = new Error('status code ' + resp.statusCode + ' requesting ' + src)
-    }
-    if (err) {
-      return emitter.emit('error', err)
-    }
-    decode(arrayBuf)
-  })
-
-  xhrProgress(xhrObject)
-    .on('data', function (amount, total) {
-      emitter.emit('progress', amount, total)
-    })
+  fetch(src)
+    .then(checkStatus)
+    .then(parseArrayBuffer)
+    .then(decode)
+    .catch(catchError)
 
   emitter.play = node.start.bind(node, 0)
   emitter.pause = node.stop.bind(node, 0)
@@ -56,6 +42,20 @@ function createBufferSource (src, opt) {
 
   return emitter
 
+  function catchError (err) {
+    emitter.emit('error', err)
+  }
+
+  function checkStatus (response) {
+    if (response.status >= 200 && response.status < 300) {
+      return response
+    } else {
+      var error = new Error(response.statusText)
+      error.response = response
+      throw error
+    }
+  }
+
   function decode (arrayBuf) {
     emitter.emit('decoding')
     audioContext.decodeAudioData(arrayBuf, function (buffer) {
@@ -70,5 +70,9 @@ function createBufferSource (src, opt) {
 
   function ended () {
     emitter.emit('end')
+  }
+
+  function parseArrayBuffer (response) {
+    return response.arrayBuffer()
   }
 }

--- a/lib/media-source.js
+++ b/lib/media-source.js
@@ -1,52 +1,29 @@
-var EventEmitter = require('events').EventEmitter
+var augmentPlayer = require('./augment-player')
 var createAudio = require('simple-media-element').audio
 var createAudioContext = require('./audio-context')
-var assign = require('object-assign')
 
 module.exports = createMediaSource
 function createMediaSource (src, opt) {
-  opt = assign({}, opt)
-  var emitter = new EventEmitter()
+  return new Promise(function(resolve, reject) {
+    opt = opt || {}
 
-  // default to Audio instead of HTMLAudioElement
-  // https://github.com/hughsk/web-audio-analyser/pull/5
-  if (!opt.element) opt.element = new window.Audio()
+    // default to Audio instead of HTMLAudioElement
+    // https://github.com/hughsk/web-audio-analyser/pull/5
+    if (!opt.element) opt.element = new window.Audio()
 
-  var audio = createAudio(src, opt)
-  var audioContext = opt.context || createAudioContext()
-  var node = audioContext.createMediaElementSource(audio)
+    var audio = createAudio(src, opt)
+    var audioContext = opt.context || createAudioContext()
+    var node = audioContext.createMediaElementSource(audio)
 
-  audio.addEventListener('ended', function () {
-    emitter.emit('end')
-  })
-
-  emitter.element = audio
-  emitter.context = audioContext
-  emitter.node = node
-  emitter.play = audio.play.bind(audio)
-  emitter.pause = audio.pause.bind(audio)
-
-  Object.defineProperties(emitter, {
-    duration: {
-      enumerable: true, configurable: true,
-      get: function () {
-        return audio.duration
-      }
-    },
-    currentTime: {
-      enumerable: true, configurable: true,
-      get: function () {
-        return audio.currentTime
-      }
-    }
-  })
-
-  startLoad()
-  return emitter
-
-  function startLoad () {
-    var done = function () {
-      emitter.emit('load')
+    function done() {
+      resolve(augmentPlayer({
+        context: audioContext,
+        isBuffer: false,
+        node: node,
+        source: audio,
+        pause: audio.pause.bind(audio, 0),
+        play: audio.play.bind(audio, 0)
+      }))
     }
 
     // On most browsers the loading begins
@@ -59,17 +36,15 @@ function createMediaSource (src, opt) {
       process.nextTick(done)
     } else {
       addOnce(audio, 'canplay', done)
-      addOnce(audio, 'error', function (err) {
-        emitter.emit('error', err)
-      })
+      addOnce(audio, 'error', reject)
     }
-  }
 
-  function addOnce (element, event, fn) {
-    function tmp (ev) {
-      element.removeEventListener(event, tmp, false)
-      fn()
+    function addOnce (element, event, fn) {
+      function tmp (ev) {
+        element.removeEventListener(event, tmp, false)
+        fn()
+      }
+      element.addEventListener(event, tmp, false)
     }
-    element.addEventListener(event, tmp, false)
-  }
+  })
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
   "dependencies": {
     "detect-audio-autoplay": "^1.0.2",
     "detect-media-element-source": "^1.0.0",
-    "object-assign": "^4.0.1",
-    "simple-media-element": "^1.0.0",
-    "whatwg-fetch": "^0.10.1"
+    "simple-media-element": "^1.0.0"
   },
   "devDependencies": {
     "tap-event": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -10,19 +10,19 @@
     "url": "https://github.com/mattdesl"
   },
   "dependencies": {
-    "detect-audio-autoplay": "^1.0.2",
-    "detect-media-element-source": "^1.0.0",
     "simple-media-element": "^1.0.0"
   },
   "devDependencies": {
-    "tap-event": "^1.0.0",
     "analyser-frequency-average": "^1.0.0",
+    "detect-audio-autoplay": "^1.0.2",
+    "detect-media-element-source": "^1.0.0",
     "browserify": "^12.0.1",
     "budo": "^6.1.0",
     "canvas-loop": "^1.0.7",
     "detect-media-element-source": "^1.0.1",
     "ios-safe-audio-context": "^1.0.0",
     "uglify-js": "^2.6.1",
+    "tap-event": "^1.0.0",
     "web-audio-analyser": "^2.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "detect-media-element-source": "^1.0.0",
     "object-assign": "^4.0.1",
     "simple-media-element": "^1.0.0",
-    "xhr": "^2.2.0",
-    "xhr-progress": "0.0.0"
+    "whatwg-fetch": "^0.10.1"
   },
   "devDependencies": {
     "tap-event": "^1.0.0",
@@ -41,7 +40,7 @@
     "audio",
     "webaudio",
     "buffer",
-    "xhr",
+    "fetch",
     "mp3",
     "browser",
     "browserify",


### PR DESCRIPTION
Hi,

I was about to write exactly this library (and probably some of its ecosystem) until I found yours :).
Great work standardising the weird bits under the hood!

I'd love it if it would be slimmer though, and I think it's totally doable :).
This PR cuts down almost half the size by implementing `fetch` instead of `xhr` and by using `Promise` instead of `EventEmitter`.
Events are gone but a communication channel can be introduced as an option if truly needed.

I'd love to hear your thoughts about this.
Thanks!
Darío
