### PR TITLE
Change touchstart to touchend

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -30,13 +30,13 @@ detectAutoplay(function (autoplay) {
 
     // On iOS, it has to be a tap event and not a drag + touchend...
     var onTap = tapEvent(function (ev) {
-      window.removeEventListener('touchstart', onTap)
+      window.removeEventListener('touchend', onTap)
       ev.preventDefault()
       loading.style.display = 'block'
       clickToPlay.style.display = 'none'
       canplay()
     })
-    window.addEventListener('touchstart', onTap)
+    window.addEventListener('touchend', onTap)
   }
 })
 


### PR DESCRIPTION
Since iOS 9, Web audio sounds have to be played at touchend, touchstart will not any more start them.
