### PR TITLE
Loop start and end

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Full list of options:
 - `volume` (Number) volume to play at
 - `buffer` (Boolean) whether to use a Buffer source, default false
 - `loop` (Boolean) whether to loop the playback, default false
+- `loopStart` (Number) point to restart loop in seconds, default 0
+- `loopEnd` (Number) point to end loop and restart in seconds, default 0
 - `crossOrigin` (String) for media element sources; optional cross origin flag
 - `context` (AudioContext) an audio context to use, defaults to a new context. You should re-use contexts, and also consider [ios-safe-audio-context](https://github.com/Jam3/ios-safe-audio-context)
 - `element` (Audio|HTMLAudioElement) an optional element to use, defaults to creating a new one. Only applicable when `buffer` is false.

--- a/lib/buffer-source.js
+++ b/lib/buffer-source.js
@@ -36,6 +36,8 @@ function createBufferSource (src, opt) {
     }
     if (loop) {
       bufferNode.loop = true
+      bufferNode.loopStart = opt.loopStart || 0
+      bufferNode.loopEnd = opt.loopEnd || 0
     }
 
     if (duration && audioCurrentTime > duration) {

--- a/lib/media-source.js
+++ b/lib/media-source.js
@@ -33,6 +33,15 @@ function createMediaSource (src, opt) {
     emitter.emit('end')
   })
 
+  if (opt.loop && (opt.loopStart || opt.loopEnd)) {
+    audio.addEventListener('timeupdate', function () {
+      var currentTime = audio.currentTime
+      if (currentTime === 0 || currentTime >= (opt.loopEnd || audio.duration)) {
+        audio.currentTime = opt.loopStart || 0
+      }
+    });
+  }
+
   emitter.element = audio
   emitter.context = audioContext
   emitter.node = node


### PR DESCRIPTION
Now [`loopStart`](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loopStart) and [`loopEnd`](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/loopEnd) can be specified in the options.

If a buffer source is used, the options are added to the `AudioBufferSourceNode` object, which knows how to handle them.

If a media source is used, `audio.currentTime` is checked each `timeupdate` event and updated if necessary.