### PR TITLE
buffer: currenttime

### DIFF
--- a/lib/buffer-source.js
+++ b/lib/buffer-source.js
@@ -75,6 +75,25 @@ function createBufferSource (src, opt) {
   emitter.context = audioContext
 
   Object.defineProperties(emitter, {
+    currentTime: {
+      enumerable: true, configurable: true,
+      get: function () {
+        if (playing) {
+          return ((rightNow() - audioStartTime) / 1000) % duration
+        } else {
+          return ((audioPauseTime - audioStartTime) / 1000) % duration
+        }
+      },
+      set: function (n) {
+        if (playing) {
+          emitter.pause()
+          audioCurrentTime = n
+          emitter.play()
+        } else {
+          audioCurrentTime = n
+        }
+      }
+    },
     duration: {
       enumerable: true, configurable: true,
       get: function () {

--- a/lib/buffer-source.js
+++ b/lib/buffer-source.js
@@ -79,9 +79,9 @@ function createBufferSource (src, opt) {
       enumerable: true, configurable: true,
       get: function () {
         if (playing) {
-          return ((rightNow() - audioStartTime) / 1000) % duration
+          return audioCurrentTime + ((rightNow() - audioStartTime) / 1000) % duration
         } else {
-          return ((audioPauseTime - audioStartTime) / 1000) % duration
+          return audioCurrentTime + ((audioPauseTime - audioStartTime) / 1000) % duration
         }
       },
       set: function (n) {

--- a/lib/buffer-source.js
+++ b/lib/buffer-source.js
@@ -87,10 +87,10 @@ function createBufferSource (src, opt) {
       set: function (n) {
         if (playing) {
           emitter.pause()
-          audioCurrentTime = n
+          audioCurrentTime = Number(n)
           emitter.play()
         } else {
-          audioCurrentTime = n
+          audioCurrentTime = Number(n)
         }
       }
     },


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

Using this in production, tested in Safari, Chrome, and Firefox.

## Problem Description

Currently, web-audio-player does not implement `.currentTime` for buffer sources.

## Solution Description

This implements that, even if the player is paused and started again.

## Side Effects, Risks, Impact

None that I know of.

- [ ] N/A

**Aditional comments:**
This is different from #7 in that it properly handles a paused and restarted player.